### PR TITLE
Unlist the MQTT Gateway API page

### DIFF
--- a/docs/user-guide/gateways-and-devices/mqtt-gateway-api.md
+++ b/docs/user-guide/gateways-and-devices/mqtt-gateway-api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+unlisted: true
 ---
 
 # MQTT Gateway API


### PR DESCRIPTION
Since its still a work in progress feature, so it should be unlisted.