### PR TITLE
Removed CONFIG environment variable from Manager UI docs

### DIFF
--- a/docs/developer-guide/working-on-ui-and-apps.md
+++ b/docs/developer-guide/working-on-ui-and-apps.md
@@ -24,9 +24,6 @@ Compiles the typescript model from java code and then starts webpack dev server 
 ### Webpack dev server environment variables
 The following environment variables can be set when running `npm run serve` using the syntax `npm run serve -- --env ENV_NAME=ENV_VALUE`:
 
-* config - To apply a custom `manager_config.json` you can set the `config` environment variable on the `npm run serve` command using a path relative to the `app/manager` directory e.g. 
-   * Windows: `npm run serve -- --env config=..\..\..\..\deployment\manager\app`
-   * Mac: `npm run serve -- --env config=../../../../deployment/manager/app`
 * managerUrl - By default webpack dev server expects the manager to be available at `http://localhost:8080` but this can be configured for example when running the manager Docker image (e.g. `npm run serve -- --env managerUrl=https://localhost`)
 * keycloakUrl - By default Keycloak expects to be available at `managerUrl/auth` but this can be configured for example when running the manager Docker image (e.g. `npm run serve -- --env keycloakUrl=https://keycloak/auth`)
 

--- a/versioned_docs/version-1.4.0/developer-guide/working-on-ui-and-apps.md
+++ b/versioned_docs/version-1.4.0/developer-guide/working-on-ui-and-apps.md
@@ -24,9 +24,6 @@ Compiles the typescript model from java code and then starts webpack dev server 
 ### Webpack dev server environment variables
 The following environment variables can be set when running `npm run serve` using the syntax `npm run serve -- --env ENV_NAME=ENV_VALUE`:
 
-* config - To apply a custom `manager_config.json` you can set the `config` environment variable on the `npm run serve` command using a path relative to the `app/manager` directory e.g. 
-   * Windows: `npm run serve -- --env config=..\..\..\..\deployment\manager\app`
-   * Mac: `npm run serve -- --env config=../../../../deployment/manager/app`
 * managerUrl - By default webpack dev server expects the manager to be available at `http://localhost:8080` but this can be configured for example when running the manager Docker image (e.g. `npm run serve -- --env managerUrl=https://localhost`)
 * keycloakUrl - By default Keycloak expects to be available at `managerUrl/auth` but this can be configured for example when running the manager Docker image (e.g. `npm run serve -- --env keycloakUrl=https://keycloak/auth`)
 


### PR DESCRIPTION
Since version 1,4.0, when https://github.com/openremote/openremote/issues/1800 got merged,
we've removed the `CONFIG=""` environment variable, since it's been served by the HTTP API now.

*This change has not been applied to custom projects, and their custom apps.*
*So I've kept the documentation on custom projects untouched.*

I've removed it from the versioned 1.4.0 docs as well, is this okay @wborn ?