### PR TITLE
Added note on ADD_ATTRIBUTE SQL function

### DIFF
--- a/docs/developer-guide/data-migration.md
+++ b/docs/developer-guide/data-migration.md
@@ -35,6 +35,7 @@ SELECT a.id, REMOVE_ATTRIBUTES(a, 'oldAttribute1', 'oldAttribute2') FROM asset a
 ```
 
 ### Add attribute to specific asset(s) (with meta items)
+**Warning**: this will override any existing attribute data!
 ```sql
 SELECT a.id, ADD_ATTRIBUTE(a, 'newAttribute2', 'GEO_JSONPoint', '1'::jsonb, now(),
     jsonb_build_object('meta1', true, 'meta2', 123))
@@ -42,6 +43,7 @@ FROM asset a WHERE...;
 ```
 
 ### Add attribute to specific asset(s) (without meta items)
+**Warning**: this will override any existing attribute data!
 ```sql
 SELECT a.id, ADD_ATTRIBUTE(a, 'newAttribute1', 'GEO_JSONPoint', '1'::jsonb, now(), null)
 FROM asset a WHERE...;


### PR DESCRIPTION
I was unaware that the `ADD_ATTRIBUTE` SQL function overrides any existing data.
I've updated the documentation, so it includes a small "warning" note.