### PR TITLE
Configure concurrency to cancel "In progress" actions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -10,6 +10,10 @@ on:
       - 'main'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # Hosted GitHub runners have 7 GB of memory available, let's use 6 GB
   NODE_OPTIONS: --max-old-space-size=6144


### PR DESCRIPTION
The styfle/cancel-workflow-action, which we use in other repositories, is no longer neccessary to accomplish this nowadays.

See: https://github.com/styfle/cancel-workflow-action

Closes #82