### PR TITLE
Fix CI/CD by pinning GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '18'
           cache: 'yarn'
@@ -40,7 +40,7 @@ jobs:
         run: yarn build
 
       - name: Upload Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: build
 
@@ -63,9 +63,9 @@ jobs:
       id-token: write
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 


### PR DESCRIPTION
CI/CD was failing with the following error:

```
The actions actions/checkout@v4, actions/setup-node@v4, actions/upload-pages-artifact@v3, actions/configure-pages@v5, and actions/deploy-pages@v4 are not allowed in openremote/documentation because all actions must be from a repository owned by openremote or created by GitHub. All actions must also be pinned to a full-length commit SHA.
```
***

This PR resolves the issue by pinning the GitHub Action versions to specific commit SHAs:

- `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4` 
  Uses the same commit SHA as the main repo.  

- `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4`
  [Release Link](https://github.com/actions/setup-node/releases/tag/v4.4.0)

- `actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4`
  [Release Link](https://github.com/actions/upload-pages-artifact/releases/tag/v4.0.0)

- `actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5`
  [Release Link](https://github.com/actions/configure-pages/releases/tag/v5.0.0)

- `actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4`
  [Release Link](https://github.com/actions/deploy-pages/releases/tag/v4.0.5)
