### PR TITLE
Revert "Increase deployment timeout to 20 minutes"

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -68,6 +68,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
-        with:
-          timeout: '1200000'
 


### PR DESCRIPTION
Reverts openremote/documentation#128 because the maximum allowed timeout value is 10 minutes (600000 milliseconds)
The previous deployments failed due to an outage on GitHub Pages.