### PR TITLE
Document map preset filter feature

### DIFF
--- a/docs/developer-guide/working-on-maps.md
+++ b/docs/developer-guide/working-on-maps.md
@@ -69,7 +69,7 @@ For configuring the geocode URL and setting up a self-hosted Nominatim instance,
 
 The `<or-map>` web component has a `showGeoCodingControl` boolean property (default: `false`) that controls whether the geocoding search box is rendered. In the Manager app (`ui/app/manager/src/pages/page-map.ts`), geocoding is enabled by default:
 
-```html
+```javascript <!-- should be lit or js-templates if it existed/worked -->
 <or-map id="map" class="or-map"
     showGeoCodingControl
     @or-map-geocoder-change="${(ev: OrMapGeocoderChangeEvent) => {
@@ -80,7 +80,7 @@ The `<or-map>` web component has a `showGeoCodingControl` boolean property (defa
 
 To enable geocoding in your own component:
 
-```html
+```javascript <!-- should be lit or js-templates if it existed/worked -->
 <or-map
     .showGeoCodingControl="${true}"
     @or-map-geocoder-change="${(ev) => {

--- a/docs/user-guide/manager-ui/appearance.md
+++ b/docs/user-guide/manager-ui/appearance.md
@@ -52,7 +52,67 @@ By default Superusers (e.g. the 'admin' user of the master realm) will see these
             ]
           }
         }
-      }
+      },
+      "clustering": {
+        "cluster": true,
+        "clusterRadius": 180,
+        "clusterMaxZoom": 17
+      },
+      "filters": [
+        {
+          "query": {
+            "types": [
+              "SoilSensorAsset"
+            ]
+          }
+        },
+        {
+          "query": {
+            "types": [
+              "HarvestRobotAsset"
+            ],
+            "attributes": {
+              "items": [
+                {
+                  "name": {
+                    "predicateType": "string",
+                    "value": "vegetableType"
+                  },
+                  "value": {
+                    "predicateType": "string",
+                    "value": "TOMATO"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "label": "Robot & Irrigation errors",
+          "query": {
+            "types": [
+              "HarvestRobotAsset",
+              "IrrigationAsset"
+            ],
+            "attributes": {
+              "items": [
+                {
+                  "name": {
+                    "predicateType": "string",
+                    "value": "notes"
+                  },
+                  "value": {
+                    "predicateType": "string",
+                    "value": "error",
+                    "match": "CONTAINS",
+                    "caseSensitive": false
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
     },
     "rules": {
       "rules": {
@@ -539,6 +599,49 @@ This configures what asset types are shown as markers on the map. The legend is 
       "legend": {
         "show": true
       }
+    }
+  }
+}
+```
+
+**Map - Preset filters:**
+This configures map preset filters, which add a dropdown on the map page to quickly filter the visible assets by type, attribute values, realm, and more using an `AssetQuery`. A live matching-asset count badge is shown per filter option. Options without a `label` will have an auto-derived label based on the type names and attribute values. Selected filters are persisted across page reloads (per user and realm) and reset on each new login session. You can also specify an optional `default` boolean or an array of `realms` to limit where the filter applies. Note that unsupported query fields like `orderBy`, `limit`, and `offset` will result in a warning.
+```json
+{
+  "pages": {
+    "map": {
+      "filters": [
+        {
+          "query": { "types": ["SoilSensorAsset"] }
+        },
+        {
+          "query": {
+            "types": ["HarvestRobotAsset"],
+            "attributes": {
+              "items": [
+                {
+                  "name": { "predicateType": "string", "value": "vegetableType" },
+                  "value": { "predicateType": "string", "value": "TOMATO" }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "label": "Robot & Irrigation errors",
+          "query": {
+            "types": ["HarvestRobotAsset", "IrrigationAsset"],
+            "attributes": {
+              "items": [
+                {
+                  "name": { "predicateType": "string", "value": "notes" },
+                  "value": { "predicateType": "string", "value": "error", "match": "CONTAINS", "caseSensitive": false }
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/docs/user-guide/manager-ui/appearance.md
+++ b/docs/user-guide/manager-ui/appearance.md
@@ -60,27 +60,29 @@ By default Superusers (e.g. the 'admin' user of the master realm) will see these
       },
       "filters": [
         {
-          "query": {
-            "types": [
-              "SoilSensorAsset"
-            ]
-          }
+          "realms": ["manufacturer"],
+          "query": { "types": ["SoilSensorAsset"] }
         },
         {
+          "label": "CO2 > 100",
+          "realms": [
+            "smartcity"
+          ],
           "query": {
             "types": [
-              "HarvestRobotAsset"
+              "EnvironmentSensorAsset"
             ],
             "attributes": {
               "items": [
                 {
                   "name": {
-                    "predicateType": "string",
-                    "value": "vegetableType"
+                    "predicateType": "number",
+                    "value": "ozoneLevel"
                   },
                   "value": {
-                    "predicateType": "string",
-                    "value": "TOMATO"
+                    "predicateType": "number",
+                    "value": 100,
+                    "operator": "GREATER_THAN"
                   }
                 }
               ]
@@ -88,24 +90,25 @@ By default Superusers (e.g. the 'admin' user of the master realm) will see these
           }
         },
         {
-          "label": "Robot & Irrigation errors",
+          "label": "Irrigation water flow > 10",
+          "realms": [
+            "manufacturer"
+          ],
           "query": {
             "types": [
-              "HarvestRobotAsset",
               "IrrigationAsset"
             ],
             "attributes": {
               "items": [
                 {
                   "name": {
-                    "predicateType": "string",
-                    "value": "notes"
+                    "predicateType": "number",
+                    "value": "flowWater"
                   },
                   "value": {
-                    "predicateType": "string",
-                    "value": "error",
-                    "match": "CONTAINS",
-                    "caseSensitive": false
+                    "predicateType": "number",
+                    "value": 10,
+                    "operator": "GREATER_THAN"
                   }
                 }
               ]
@@ -612,30 +615,56 @@ This configures map preset filters, which add a dropdown on the map page to quic
     "map": {
       "filters": [
         {
+          "realms": ["manufacturer"],
           "query": { "types": ["SoilSensorAsset"] }
         },
         {
+          "label": "CO2 > 100",
+          "realms": [
+            "smartcity"
+          ],
           "query": {
-            "types": ["HarvestRobotAsset"],
+            "types": [
+              "EnvironmentSensorAsset"
+            ],
             "attributes": {
               "items": [
                 {
-                  "name": { "predicateType": "string", "value": "vegetableType" },
-                  "value": { "predicateType": "string", "value": "TOMATO" }
+                  "name": {
+                    "predicateType": "number",
+                    "value": "ozoneLevel"
+                  },
+                  "value": {
+                    "predicateType": "number",
+                    "value": 100,
+                    "operator": "GREATER_THAN"
+                  }
                 }
               ]
             }
           }
         },
         {
-          "label": "Robot & Irrigation errors",
+          "label": "Irrigation water flow > 10",
+          "realms": [
+            "manufacturer"
+          ],
           "query": {
-            "types": ["HarvestRobotAsset", "IrrigationAsset"],
+            "types": [
+              "IrrigationAsset"
+            ],
             "attributes": {
               "items": [
                 {
-                  "name": { "predicateType": "string", "value": "notes" },
-                  "value": { "predicateType": "string", "value": "error", "match": "CONTAINS", "caseSensitive": false }
+                  "name": {
+                    "predicateType": "number",
+                    "value": "flowWater"
+                  },
+                  "value": {
+                    "predicateType": "number",
+                    "value": 10,
+                    "operator": "GREATER_THAN"
+                  }
                 }
               ]
             }


### PR DESCRIPTION
### Changes

- Adds example and short description of the preset filters to "appearance page" documentation page
- Adjusts the language used for the geocoding codeblocks to `javascript` for better highlighting.

### Notes

I tried to use [js-templates](https://github.com/PrismJS/prism/blob/v2/src/languages/js-templates.js) for the codeblocks but that didn't seem to work. Might need to update prism.js for that.