### PR TITLE
Update NodeJS version requirement to >=20.19

### DIFF
--- a/docs/developer-guide/010-preparing-the-environment.md
+++ b/docs/developer-guide/010-preparing-the-environment.md
@@ -22,7 +22,7 @@ For development you need the following in addition to the runtime tooling:
 * Java 21 JDK ([OpenJDK](https://openjdk.java.net/), [Oracle Java SE JDK](https://www.oracle.com/technetwork/java/javase/downloads/index.html))
 * [Git](https://git-scm.com/downloads)
 * [Git LFS](https://git-lfs.com/) `git lfs install`
-* [NodeJS](https://nodejs.org/en/download/current/) (>=20.0, on macOS you can use [Homebrew](https://brew.sh/) and `brew install node@20`)
+* [NodeJS](https://nodejs.org/en/download/current/) (>=20.19, on macOS you can use [Homebrew](https://brew.sh/) and `brew install node@20`)
 * [yarn](https://yarnpkg.com/getting-started/install) `corepack enable; yarn init -2` (>=3.2.0)
 
 Ensure the following commands execute successfully:


### PR DESCRIPTION
## Description
In the `openremote/openremote` repository, we're updating the RSPack bundler dependency from v1 to v2.
This means the minimum NodeJS version has been bumped to `20.19+`.
Although most users will install the latest LTS (`v22.X`), it's worth updating the docs.

Blocked by https://github.com/openremote/openremote/pull/3219