### PR TITLE
Clarify marker configuration details in user guide

### DIFF
--- a/docs/user-guide/020-manager-ui/30-appearance.md
+++ b/docs/user-guide/020-manager-ui/30-appearance.md
@@ -559,9 +559,10 @@ You can set the attributes to exclude (or include) on the top right card of the 
 
 #### Marker Configuration
 
-This configures how map markers behave. Markers can change colour based on an attribute value, show an attribute value as a label with or without units, and optionally hide the asset direction.
-
+This configures how map markers behave.
+Markers can change colour based on an attribute value, show an attribute value as a label with or without units, and optionally hide the asset direction.
 Marker colours can be configured using numeric ranges, string values, or boolean values.
+Note that this part of the config is not yet configured in the manager_config of the manager demo.
 
 ```json
 {

--- a/docs/user-guide/020-manager-ui/30-appearance.md
+++ b/docs/user-guide/020-manager-ui/30-appearance.md
@@ -556,9 +556,13 @@ You can set the attributes to exclude (or include) on the top right card of the 
   }
 }
 ```
+
 #### Marker Configuration
 
-This configures how the markers behave. They can either change their colour based on an attribute value (number, boolean, or string), show a label with or without units, and/or show the direction an asset is facing. Note that this part of the config is not yet configured in the manager_config of the manager demo.
+This configures how map markers behave. Markers can change colour based on an attribute value, show an attribute value as a label with or without units, and optionally hide the asset direction.
+
+Marker colours can be configured using numeric ranges, string values, or boolean values.
+
 ```json
 {
   "pages": {
@@ -585,12 +589,44 @@ This configures how the markers behave. They can either change their colour base
               }
             ]
           }
+        },
+        "GatewayAsset": {
+          "attributeName": "status",
+          "showLabel": true,
+          "colours": {
+            "type": "string",
+            "CONNECTED": "39B54A",
+            "DISCONNECTED": "C1272D"
+          }
+        },
+        "PresenceSensorAsset": {
+          "attributeName": "presence",
+          "colours": {
+            "type": "boolean",
+            "true": "39B54A",
+            "false": "C1272D"
+          }
         }
       }
     }
   }
 }
 ```
+
+The `attributeName` property specifies the asset attribute used by the marker configuration.
+
+When `showLabel` is `true`, the current attribute value is shown next to the marker. By default, units are included when available. Set `showUnits` to `false` to hide them.
+
+The `colours` property changes the marker colour based on the current attribute value:
+
+* `range` selects a colour based on the configured numeric ranges.
+* `string` selects the colour whose key exactly matches the string representation of the attribute value.
+* `boolean` selects either the `"true"` or `"false"` colour.
+
+Set `hideDirection` to `true` to hide the direction indicator for assets that have a direction attribute.
+
+Colours are specified as hexadecimal RGB values without the `#` prefix.
+
 #### Clustering Configuration
 
 This configures how clustering behaves. Clustering ensures the map page can render assets smoothly even with 40-50 thousand assets. The clustering option can be disabled, or changed to cluster markers in a smaller radius showing more clusters and changed to start clustering at a certain zoom level. Note that reducing cluster radius or cluster max zoom can have performance impacts. The recommended cluster max zoom level is Maximum realm zoom level - 2.


### PR DESCRIPTION
Updated the marker configuration section to clarify how markers behave, including color changes based on attributes and label display options. Added details on the `attributeName` property and color selection methods.